### PR TITLE
keep the "#" links from de-centering the headers

### DIFF
--- a/public/globals.css
+++ b/public/globals.css
@@ -104,6 +104,10 @@ main h2 {
     font-family: var(--font-pt-serif-caption);
     text-align: center;
     border: none;
+    position: relative;
+}
+main h2 .subheading-anchor {
+    position: absolute; /* keep the "#" link from de-centering the header text */
 }
 main p {
     font-family: var(--font-pt-serif-caption);


### PR DESCRIPTION
This fixes the alignment between headings and subheadings by making the `#` hover link not participate in the text flow.

Before and after:

<img width="734" height="250" alt="CleanShot 2025-07-23 at 06 23 44@2x" src="https://github.com/user-attachments/assets/7b1fa3f1-40a5-42c7-b5a5-f2178b646c2c" />
<img width="734" height="250" alt="CleanShot 2025-07-23 at 06 24 01@2x" src="https://github.com/user-attachments/assets/c780f4ae-ad17-482f-a314-4de04f9ef798" />

---

When hovering, the anchor link still appears after the last word:

<img width="734" height="250" alt="CleanShot 2025-07-23 at 06 27 24@2x" src="https://github.com/user-attachments/assets/4aec74e9-c62f-4ebc-b37a-610f7a4c7419" />
