### PR TITLE
add hanging indent to hymns of praise

### DIFF
--- a/public/globals.css
+++ b/public/globals.css
@@ -143,6 +143,7 @@ main p {
 
 blockquote {
     border: none;
+    text-indent: 1em hanging each-line;
 }
 
 ol li::marker {


### PR DESCRIPTION
For the hymns of praise, the kindle version of the Prologue uses a hanging indent for lines that have to be wrapped.  It’s a simple option for Safari and Firefox, and Chrome may support it eventually.

<table>
<tr><td>before</td><td>after</td><td>kindle reference</td></tr>
<tr><td><img width="672" height="1234" alt="CleanShot 2025-07-25 at 23 38 43@2x" src="https://github.com/user-attachments/assets/12a19097-9129-4431-9938-71f70895d2a2" /></td><td><img width="672" height="1234" alt="CleanShot 2025-07-25 at 23 38 15@2x" src="https://github.com/user-attachments/assets/6d4cc158-796f-48dd-a067-3beacfd89220" /></td><td><img width="892" height="1434" alt="CleanShot 2025-07-25 at 23 42 08@2x" src="https://github.com/user-attachments/assets/baca15bf-f5ab-40c4-9b22-3ca5d25590cd" />
</td></tr></table>

