### PR TITLE
fix front-page mdx formatting by not removing empty lines

### DIFF
--- a/app/api/mdx/route.js
+++ b/app/api/mdx/route.js
@@ -22,11 +22,8 @@ export async function GET(request) {
       // Read the MDX file
       let mdxContent = await readFile(filePath, 'utf-8')
       
-      // Remove import statements since components are provided via MDXRemote
-      mdxContent = mdxContent.replace(/^import\s+.*$/gm, '')
-      
-      // Clean up any empty lines left by removed imports
-      mdxContent = mdxContent.replace(/^\s*\n/gm, '')
+      // Remove import statement lines since components are provided via MDXRemote
+      mdxContent = mdxContent.replace(/^import\s+.*\n/gm, '')
       
       return new Response(mdxContent, {
         headers: {


### PR DESCRIPTION
Front page content is formatted differently from the calendar urls.

1. All the Homily paragraphs are collapsed into one
2. Contemplation list items have the wrong font

Claude discovered that this is caused by empty lines being removed from the MDX, only on the dynamic mdx endpoint.  List items have the wrong font because they're rendered without the `<p>` tags when surrounding empty lines are removed.

---

front page fetches the dynamic mdx here:

https://github.com/jaredef/ochrid/blob/2527238e37fbb81ef94e6571fcae8cc308fd185c/components/DynamicMDXContent.jsx#L51-L53

the mdx endpoint removes import statements and all empty lines

https://github.com/jaredef/ochrid/blob/2527238e37fbb81ef94e6571fcae8cc308fd185c/app/api/mdx/route.js#L25-L29